### PR TITLE
give a non-zero exit code when validation fails

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,6 +44,24 @@ validator(opts, function (error, data) {
     console.error(error)
     process.exit(1)
   } else {
-    console.log(opts.format === 'json' ? JSON.stringify(data) : data)
+    var msg
+    var validationFailed = false
+
+    if (opts.format === 'json') {
+      msg = JSON.stringify(data)
+      if (data.messages.length) {
+        validationFailed = true
+      }
+    } else {
+      msg = data
+      if (data.includes('There were errors')) {
+        validationFailed = true
+      }
+    }
+
+    console.log(msg)
+    if (validationFailed) {
+      process.exit(2)
+    }
   }
 })

--- a/test/cli-test.js
+++ b/test/cli-test.js
@@ -48,6 +48,13 @@ tap.test('It returns error on error', function testError (test) {
   })
 })
 
+tap.test('It returns error on validation failure', function testError (test) {
+  exec('./index.js', ['--file=test/data/invalid.html'], function versionWithV (error, stdout, stderr) {
+    test.ok(error, 'Error OK')
+    test.end()
+  })
+})
+
 tap.test('It returns data if url supplied', function testError (test) {
   exec('./index.js', ['https://www.github.com'], function versionWithV (error, stdout, stderr) {
     if (error) {
@@ -59,20 +66,14 @@ tap.test('It returns data if url supplied', function testError (test) {
 })
 
 tap.test('It returns data if file supplied', function testError (test) {
-  exec('./index.js', ['--file=test/data/invalid.html'], function versionWithV (error, stdout, stderr) {
-    if (error) {
-      throw error
-    }
+  exec('./index.js', ['--file=test/data/invalid.html'], function versionWithV (_, stdout, stderr) {
     test.ok(stdout.toString().trim(), 'Data OK')
     test.end()
   })
 })
 
-tap.test('It returns data on supplied supplied format', function testError (test) {
-  exec('./index.js', ['--file=test/data/invalid.html', '--format=json'], function versionWithV (error, stdout, stderr) {
-    if (error) {
-      throw error
-    }
+tap.test('It returns data in supplied format', function testError (test) {
+  exec('./index.js', ['--file=test/data/invalid.html', '--format=json'], function versionWithV (_, stdout, stderr) {
     test.equal(JSON.parse(stdout.toString().trim()).messages.length, 3)
     test.end()
   })


### PR DESCRIPTION
Fixes https://github.com/zrrrzzt/html-validator-cli/issues/1.

Previously, the CLI would only fail in cases where the file/URL couldn't be found. Now, it will fail in those cases, as well as if the markup is found to be invalid. This is the behavior I (and I think others?) would expect, but curious to hear thoughts. Thanks!

/cc @mikebell @radek-holy 