### PR TITLE
Adding headers to Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,11 @@ Optional pass in strings to ignore
 ```
 $ html-validator <url> --ignore='Error: Stray end tag “div”.' --ignore='Error: Stray end tag “body”.'
 ```
+Optional pass in headers
+
+```
+$ html-validator <url> --headers='{"foo":"doo"}'
+```
 
 To get full result from validator use --verbose
 

--- a/index.js
+++ b/index.js
@@ -40,6 +40,10 @@ if (argv.validator) {
   options.validator = argv.validator
 }
 
+if (argv.headers) {
+  options.headers = JSON.parse(argv.headers)
+}
+
 if (argv.file) {
   options.data = fs.readFileSync(argv.file)
 }

--- a/test/cli-test.js
+++ b/test/cli-test.js
@@ -63,6 +63,16 @@ tap.test('It returns correct message on validation success', function testSucces
   })
 })
 
+tap.test('You can supply headers', function testSuccess (test) {
+  exec('./index.js', [`--file=test/data/valid.html`, `--headers=${JSON.stringify({ foo: 'bar' })}`], (error, stdout, stderr) => {
+    if (error) {
+      throw error
+    }
+    test.ok(stdout.toString().trim(), 'Data OK')
+    test.end()
+  })
+})
+
 tap.test('It returns data if file supplied', function testError (test) {
   exec('./index.js', ['--file=test/data/valid.html'], function versionWithV (error, stdout, stderr) {
     if (error) {


### PR DESCRIPTION
Was needing to add headers to the request.options. This is needed if you are to pass in basic auth for testing.