### PR TITLE
package.json: specify the files to include in the npm package.

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,5 +43,9 @@
     "coveralls": "3.0.2",
     "standard": "12.0.1",
     "tap": "12.0.1"
-  }
+  },
+  "files": [
+    "lib/*.{js,json}",
+    "index.js"
+  ]
 }


### PR DESCRIPTION
```
C:\Users\xmr\Desktop\html-validator-cli>npm pack --dry
npm notice
npm notice package: html-validator-cli@4.1.3
npm notice === Tarball Contents ===
npm notice 1.3kB package.json
npm notice 2.3kB index.js
npm notice 1.1kB LICENSE
npm notice 2.2kB README.md
npm notice 114B  lib/getHelpText.js
npm notice 843B  lib/helptext.json
npm notice === Tarball Details ===
npm notice name:          html-validator-cli
npm notice version:       4.1.3
npm notice filename:      html-validator-cli-4.1.3.tgz
npm notice package size:  3.0 kB
npm notice unpacked size: 7.8 kB
npm notice shasum:        8ffada66329bbcb5e8406d227a167b34ef384c02
npm notice integrity:     sha512-CtvD9SajLxJF1[...]m+rAOBFAsWh7A==
npm notice total files:   6
npm notice
html-validator-cli-4.1.3.tgz
```